### PR TITLE
Update github actions plugin versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v6
-    - uses: cachix/cachix-action@v3  # This also runs nix-build.
+    - uses: cachix/install-nix-action@v12
+    - uses: cachix/cachix-action@v8  # This also runs nix-build.
       with:
         name: srid


### PR DESCRIPTION
The current plugin versions result in errors when building: 
https://github.com/Nimor111/rib-testing/runs/2111425949 

This PR updates the plugins to working versions.